### PR TITLE
use python uproot3 and awkward0 to remain compatible

### DIFF
--- a/src/UpROOT.jl
+++ b/src/UpROOT.jl
@@ -22,8 +22,8 @@ include("tdirectory.jl")
 include("ttree.jl")
 
 function __init__()
-    copy!(awkward, pyimport_conda("awkward", "awkward", "conda-forge"))
-    copy!(uproot, pyimport_conda("uproot", "uproot", "conda-forge"))
+    copy!(awkward, pyimport_conda("awkward0", "awkward0", "conda-forge"))
+    copy!(uproot, pyimport_conda("uproot3", "uproot3", "conda-forge"))
     copy!(numpy, pyimport("numpy"))
 
     for k in _testfile_keys


### PR DESCRIPTION
At present, as already mentioned in a former issue, one should use the Python packages uproot3 and awkward0 to remain compatible with the Python evolution to uproot = uproot4 and awkward = awkward1. This super simple patch achieves that. Works for me in a minimal test.